### PR TITLE
Handle the case where the last N images are corrupt in a bundle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,14 @@
 flake8==6.1.0
 importlib-metadata==6.8.0
+iniconfig==2.0.0
 mccabe==0.7.0
 mypy==1.7.0
 mypy-extensions==1.0.0
 numpy==1.26.2
+packaging==23.2
+Pillow==10.1.0
 platformdirs==4.0.0
+pluggy==1.3.0
 pycodestyle==2.11.1
 pyflakes==3.1.0
 PyQt6==6.6.0
@@ -12,8 +16,10 @@ PyQt6-Qt6==6.6.0
 PyQt6-sip==13.6.0
 PySide6-Addons==6.6.0
 PySide6-Essentials==6.6.0
+pytest==7.4.3
 shiboken6==6.6.0
 tomli==2.0.1
+types-Pillow==10.1.0.2
 typing_extensions==4.8.0
 yapf==0.40.2
 zipp==3.17.0

--- a/src/main.py
+++ b/src/main.py
@@ -214,8 +214,8 @@ class App(QWidget):
 
                     # If we got here, the image is valid, and the label should
                     # be created before continuing.
-                    self.error_dialog.showMessage("WARNING: Missing label at %r" %
-                                                  label_path)
+                    self.error_dialog.showMessage(
+                        "WARNING: Missing label at %r" % label_path)
                     return
                 except PIL.UnidentifiedImageError:
                     # The image is invalid. Don't care about it missing a

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,8 @@ from PyQt6.QtWidgets import (QApplication, QErrorMessage, QGestureEvent,
                              QFileDialog, QToolBar)
 from PyQt6.QtGui import QKeyEvent, QPixmap
 from PyQt6.QtCore import QEvent, QObject, QPointF, QRectF, Qt
+import PIL
+from PIL import Image
 
 
 class DraggableRectItem(QGraphicsRectItem):
@@ -200,12 +202,25 @@ class App(QWidget):
             name, _ext = os.path.splitext(file)
 
             label_path = os.path.join(bundle_path, name + ".label")
-            if not os.path.exists(label_path):
-                self.error_dialog.showMessage("WARNING: Missing label at %r" %
-                                              label_path)
-                return
-            else:
+            if os.path.exists(label_path):
                 images_and_labels.append((label_path, image_path, name))
+            else:
+                # Maybe the image here is invalid? (In many of our bundles,
+                # images were corrupted as we were saturating the pi's SD all
+                # the way until shutdown. This meant that not all image file
+                # contents could properly be flushed to disk.)
+                try:
+                    Image.open(image_path)
+
+                    # If we got here, the image is valid, and the label should
+                    # be created before continuing.
+                    self.error_dialog.showMessage("WARNING: Missing label at %r" %
+                                                  label_path)
+                    return
+                except PIL.UnidentifiedImageError:
+                    # The image is invalid. Don't care about it missing a
+                    # .label file. Don't add it to the complete bundle either.
+                    pass
 
         with zipfile.ZipFile(completed_bundle, "w") as zip:
             for label_path, image_path, name in images_and_labels:


### PR DESCRIPTION
Ritish found this bug with bundle 24. We now ignore corrupt (or otherwise invalid) images when saving a bundle.